### PR TITLE
Add demo showing breaking case for LiveView content updating

### DIFF
--- a/demo/lib/demo_web/components/layouts.ex
+++ b/demo/lib/demo_web/components/layouts.ex
@@ -172,6 +172,14 @@ defmodule DemoWeb.Layouts do
                       States
                     </.link>
                   </li>
+                  <li>
+                    <.link
+                      href={~p"/updating_content"}
+                      class="-ml-px block border-l pl-4 border-border text-muted-foreground hover:border-primary hover:text-primary"
+                    >
+                      Updating Content
+                    </.link>
+                  </li>
                 </div>
               </ul>
             </div>

--- a/demo/lib/demo_web/live/updating_content_live.ex
+++ b/demo/lib/demo_web/live/updating_content_live.ex
@@ -1,0 +1,39 @@
+defmodule DemoWeb.UpdatingContentLive do
+  use DemoWeb, :live_view
+
+  def mount(_params, _session, socket) do
+    socket = create_cards(socket)
+    {:ok, socket}
+  end
+
+  defp card(assigns) do
+    ~H"""
+    <div phx-click="toggle_card" phx-value-id={@id} class="w-full">
+      <h2>{@title}</h2>
+      <p :if={@expanded}>{@content}</p>
+    </div>
+    """
+  end
+
+  defp create_cards(socket) do
+    cards =
+      for i <- 1..10, do: %{id: "card_#{i}", title: "Card #{i}", content: "Content for card #{i}"}
+
+    expanded_cards = MapSet.new()
+
+    socket
+    |> assign(:cards, cards)
+    |> assign(:expanded_cards, expanded_cards)
+  end
+
+  def handle_event("toggle_card", %{"id" => id}, socket) do
+    expanded_cards = socket.assigns.expanded_cards
+
+    expanded_cards =
+      if MapSet.member?(expanded_cards, id),
+        do: MapSet.delete(expanded_cards, id),
+        else: MapSet.put(expanded_cards, id)
+
+    {:noreply, assign(socket, :expanded_cards, expanded_cards)}
+  end
+end

--- a/demo/lib/demo_web/live/updating_content_live.html.heex
+++ b/demo/lib/demo_web/live/updating_content_live.html.heex
@@ -1,0 +1,93 @@
+<div class="mx-auto w-full min-w-0 max-w-3xl pt-8">
+  <header class="prose relative mb-4 max-w-3xl border-b border-border pb-8  ">
+    <p class="mb-4 text-sm/6 font-medium capitalize text-accent-foreground"></p>
+
+    <h1 class="mb-6 scroll-m-20 text-4xl font-bold tracking-tight">
+      Update content contained within a pane
+    </h1>
+
+    <p class="mt-2 text-balance text-lg text-muted-foreground">
+      An example of how to update the content contained within a pane.
+    </p>
+  </header>
+
+  <div class="markdown prose relative max-w-3xl pt-4">
+    <p class="leading-7 [&amp;:not(:first-child)]:mt-6">
+      The <code>pane</code> component has a <code>content</code> slot
+      that can be used to update the content contained within a pane.
+    </p>
+
+    <p class="mb-10">
+      We send an event to the LiveView when the pane is collapsed or expanded with a payload containing
+      the id so we can identify which pane was collapsed or expanded. We react to this event by updating the
+      button text to the correct action.
+    </p>
+    <LivePane.group
+      id="demo_updating_content"
+      class="h-[450px] border-2 border-gray-300 rounded-lg bg-inherit"
+      direction="vertical"
+    >
+      <LivePane.pane
+        collapsible={true}
+        collapsed_size={5}
+        min_size={15}
+        starting_size={15}
+        group_id="demo_updating_content"
+        id="demo_pane_1"
+        class="
+          w-full bg-gray-100 data-[pane-state=collapsing]:bg-red-200 data-[pane-state=collapsed]:bg-red-200
+          data-[pane-state=collapsing]:transition-[flex-grow,background-color] data-[pane-state=collapsing]:duration-1000
+          data-[pane-state=collapsing]:ease-linear data-[pane-state=collapsing]:will-change-[flex-grow,background-color]
+          data-[pane-state=expanding]:bg-gray-100 data-[pane-state=expanding]:transition-[flex-grow,background-color]
+          data-[pane-state=expanding]:duration-1000 data-[pane-state=expanding]:ease-linear
+          data-[pane-state=expanding]:will-change-[flex-grow,background-color]
+        "
+      >
+        <div class="flex w-full items-center justify-center rounded-lg p-6">
+          <span class="font-semibold">
+            Top panel
+          </span>
+        </div>
+      </LivePane.pane>
+
+      <LivePane.resizer
+        id="demo_updating_content-resizer"
+        group_id="demo_updating_content"
+        class="relative flex w-full h-2 items-center justify-center"
+      >
+        <div class="z-10 h-7 flex items-center w-4 rounded-sm border bg-brand">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="currentColor"
+            viewBox="0 0 256 256"
+            class="size-4 text-black"
+          >
+            <rect width="256" height="256" fill="none"></rect>
+            <path d="M108,60A16,16,0,1,1,92,44,16,16,0,0,1,108,60Zm56,16a16,16,0,1,0-16-16A16,16,0,0,0,164,76ZM92,112a16,16,0,1,0,16,16A16,16,0,0,0,92,112Zm72,0a16,16,0,1,0,16,16A16,16,0,0,0,164,112ZM92,180a16,16,0,1,0,16,16A16,16,0,0,0,92,180Zm72,0a16,16,0,1,0,16,16A16,16,0,0,0,164,180Z">
+            </path>
+          </svg>
+        </div>
+      </LivePane.resizer>
+      <LivePane.pane
+        starting_size={50}
+        group_id="demo_updating_content"
+        id="demo_pane_2"
+        class="w-full bg-gray-100"
+      >
+        <div class="overflow-auto">
+          <div class="flex flex-col gap-2 w-full items-center justify-center rounded-lg p-2">
+            <.card
+              :for={card <- @cards}
+              id={card.id}
+              title={card.title}
+              content={card.content}
+              expanded={MapSet.member?(@expanded_cards, card.id)}
+            />
+          </div>
+        </div>
+      </LivePane.pane>
+    </LivePane.group>
+  </div>
+</div>

--- a/demo/lib/demo_web/router.ex
+++ b/demo/lib/demo_web/router.ex
@@ -25,6 +25,7 @@ defmodule DemoWeb.Router do
     live "/collapsible", CollapsibleLive, :collapsible
     live "/conditional", ConditionalLive, :conditional
     live "/states", StatesLive, :states
+    live "/updating_content", UpdatingContentLive, :updating_content
 
     get "/persistent", PageController, :persistent
   end


### PR DESCRIPTION
This is a small sample showing a breaking case where LiveView creates a DOM update below a LivePane.pane, causing the style attribute of the div implementing the pane to be removed, so the pane no longer renders correctly. Click on one of the items in the bottom pane to see how it all goes bad.

I'll raise an issue separately. I'm pretty sure the pane hook needs to implement `updated()` to recalc and reapply the style - currently they are only applied on `mounted()`.