### PR TITLE
Relax phoenix_live_view version requirement to support LiveView 1.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule LivePane.MixProject do
   defp deps do
     [
       {:phoenix, "~> 1.8"},
-      {:phoenix_live_view, "~> 1.1.0"},
+      {:phoenix_live_view, "~> 1.1"},
       #
       {:bandit, "~> 1.5", only: :dev},
       {:credo, ">= 0.0.0", only: [:dev], runtime: false},


### PR DESCRIPTION
First of all, thank you for the great library!

Currently, the version requirement for `phoenix_live_view` is a bit strict and requires an override for LiveView 1.2+. I don't see any reason this library wouldn't work fine on 1.2, and testing it locally it seems to work as expected.

This PR relaxes the version requirement accordingly.